### PR TITLE
Add static `using` iterator helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ export const AsyncDisposable: AggregateAsyncDisposableConstructor;
 
 ### `using` helper: add resources for tracking
 
-The `AggregateDisposable` and `AggregateAsyncDisposable` objects expose a `using` helper on their instance which can be used to add resources for tracking after construction of the aggregate object. The `using` helper can be detached from the aggregate object (it's bound at construction). It passes through its value for chaining, or assignment at acquisition time. `using` accepts a dispose callback function as an optional argument. This can be used to implement disposal for values which do not implement the disposables interfaces. In that case the value is passed as `this` context to the dispose callback
+The `AggregateDisposable` and `AggregateAsyncDisposable` objects expose a `using` helper on their instance which can be used to add resources for tracking after construction of the aggregate object. The `using` helper can be detached from the aggregate object (it's bound at construction). Calling `using` after the aggregate has been disposed throws an error. It passes through its value for chaining, or assignment at acquisition time. `using` accepts a dispose callback function as an optional argument. This can be used to implement disposal for values which do not implement the disposables interfaces. In that case the value is passed as `this` context to the dispose callback
 
 #### Aggregate `Disposable`
 
@@ -238,8 +238,6 @@ interface AggregateAsyncDisposableUsing {
   <T>(value: T, onDispose: OnAsyncDispose): T;
 }
 ```
-
-The `Disposable`'s `using` helper function can be used to track any _disposable like_ resource. It captures the _disposable_ and its dispose method, or the dispose callback, then passes through the value. Additionally `using` can be called with an `onDispose` callback as second argument, which will be called with the value as `this` context. When the aggregate object is disposed of, the tracked resources are disposed of in reverse order to which they were added.
 
 The `AsyncDisposable`'s `using` helper function can be used to track any _disposable_ or _async disposable like_ resource. It captures the _disposable_ and its dispose method, the _async disposable_ and its async dispose method, or the async dispose callback, then passes through the value. Additionally `using` can be called with an `onDispose` async callback as second argument, which will be called with the value as `this` context. When the aggregate async object is disposed of, the tracked resources are disposed of in reverse order to which they were added.
 

--- a/async-disposable.d.ts
+++ b/async-disposable.d.ts
@@ -87,12 +87,35 @@ declare namespace AsyncDisposable {
     ): AsyncIterable<T>;
 
     /**
-     * Returns an iterator which yields a new async aggregate instance. Its `using`
-     * helper can be used to track disposable or async disposable resources
-     * which will be disposed of when the iterator is closed. Use with a
-     * `for-await-of` statement to perform RAII style explicit resource management
+     * Returns an async iterator which yields the provided async disposable
+     * resource, and disposes of the resource at close. Use with a
+     * `for-await-of` statement to ensure the iterator is closed and the
+     * resource disposed of after usage.
+     *
+     * @param disposable The disposable resource to track
      */
-    [Symbol.asyncIterator](): UsingAsyncIterator;
+    using<T extends Resource>(disposable: T): UsingIterator<T>;
+
+    /**
+     * Returns an async iterator which yields the provided resource, and
+     * disposes of the resource with the specified async dispose callback at
+     * close. Use with a `for-await-of` statement to ensure the iterator is
+     * closed and the resource disposed of after usage.
+     *
+     * @param value A value to consider as a resource to dispose
+     * @param onDispose The async dispose callback invoked with the value
+     * as `this` context
+     */
+    using<T>(value: T, onDispose: OnDispose<T>): UsingIterator<T>;
+
+    /**
+     * Returns an async iterator which yields a new async aggregate instance.
+     * Its `using` helper can be used to track disposable or async disposable
+     * resources which will be disposed of when the iterator is closed. Use
+     * with a `for-await-of` statement to perform RAII style explicit resource
+     * management
+     */
+    [Symbol.asyncIterator](): UsingIterator<Aggregate>;
   }
 
   export interface Using {
@@ -119,7 +142,7 @@ declare namespace AsyncDisposable {
 
   export type Resource<T = void> = Disposable | AsyncDisposable | OnDispose<T>;
 
-  export type UsingAsyncIterator = AsyncIterator<Aggregate, void, void>;
+  export type UsingIterator<T> = AsyncIterableIterator<T>;
 }
 
 export declare const AsyncDisposable: AsyncDisposable.Constructor;

--- a/async-disposable.js
+++ b/async-disposable.js
@@ -215,9 +215,10 @@ const wrapIterator = (iter, getDisposable) => {
 };
 
 /**
- * @param {DisposableAggregate} value
+ * @template T
+ * @param {T} value
  * @param {IAsyncDisposable} disposable
- * @returns {import("./async-disposable.js").AsyncDisposable.UsingAsyncIterator}
+ * @returns {import("./async-disposable.js").AsyncDisposable.UsingIterator<T>}
  */
 const getIterator = (value, disposable) => {
   /** @type {IAsyncDisposable | undefined} */
@@ -479,6 +480,17 @@ export const AsyncDisposable = /** @type {DisposableConstructor} */ (
           return wrapIterator(iterator, mapFn);
         },
       };
+    }
+
+    /**
+     * @param {any} value
+     * @param {DisposeMethod} [onDispose]
+     */
+    static using(value, onDispose) {
+      // Wrap value even if it's already a disposable
+      const disposable = new (this || AsyncDisposable)();
+      disposable.using(value, onDispose);
+      return getIterator(value, disposable);
     }
 
     static [Symbol.asyncIterator]() {

--- a/async-disposable.js
+++ b/async-disposable.js
@@ -78,6 +78,28 @@ const addDisposable = (disposable, resource, stack, onError) => {
 };
 
 /**
+ * @param {unknown} error
+ * @param {unknown} cause
+ */
+const mergeCause = (error, cause) => {
+  let result;
+
+  try {
+    if (!("cause" in /** @type {Object}*/ (error))) {
+      Object.defineProperty(error, "cause", {
+        value: cause,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      });
+      result = error;
+    }
+  } catch (e) {}
+
+  return result || new AggregateError([cause, error]);
+};
+
+/**
  * @param {Iterator<unknown> | AsyncIterator<unknown>} iter
  * @param {MapFn} getDisposable
  */
@@ -319,12 +341,7 @@ export const AsyncDisposable = /** @type {DisposableConstructor} */ (
         } else {
           error = new AggregateError(errors);
           if (iterationError) {
-            Object.defineProperty(error, "cause", {
-              value: iterationError,
-              enumerable: false,
-              writable: true,
-              configurable: true,
-            });
+            error = mergeCause(error, iterationError);
           }
         }
         if (syncDone) {
@@ -429,17 +446,7 @@ export const AsyncDisposable = /** @type {DisposableConstructor} */ (
               res = undefined;
             }
           } catch (disposeError) {
-            if (!("cause" in /** @type {Object}*/ (disposeError))) {
-              Object.defineProperty(disposeError, "cause", {
-                value: err,
-                enumerable: false,
-                writable: true,
-                configurable: true,
-              });
-              throw disposeError;
-            } else {
-              throw new AggregateError([err, disposeError]);
-            }
+            err = mergeCause(disposeError, err);
           }
           throw err;
         },

--- a/disposable.d.ts
+++ b/disposable.d.ts
@@ -69,12 +69,33 @@ declare namespace Disposable {
     ): Iterable<T>;
 
     /**
+     * Returns an iterator which yields the provided disposable resource, and
+     * disposes of the resource at close. Use with a `for-of` statement to
+     * ensure the iterator is closed and the resource disposed of after usage.
+     *
+     * @param disposable The disposable resource to track
+     */
+    using<T extends Resource>(disposable: T): UsingIterator<T>;
+
+    /**
+     * Returns an iterator which yields the provided resource, and disposes of
+     * the resource with the specified dispose callback at close. Use with a
+     * `for-of` statement to ensure the iterator is closed and the resource
+     * disposed of after usage.
+     *
+     * @param value A value to consider as a resource to dispose
+     * @param onDispose The dispose callback invoked with the value
+     * as `this` context
+     */
+    using<T>(value: T, onDispose: OnDispose<T>): UsingIterator<T>;
+
+    /**
      * Returns an iterator which yields a new aggregate instance. Its `using`
      * helper can be used to track disposable resources which will be disposed
      * of when the iterator is closed. Use with a `for-of` statement to perform
      * RAII style explicit resource management
      */
-    [Symbol.iterator](): UsingIterator;
+    [Symbol.iterator](): UsingIterator<Aggregate>;
   }
 
   export interface Using {
@@ -101,7 +122,7 @@ declare namespace Disposable {
 
   export type Resource<T = void> = Disposable | OnDispose<T>;
 
-  export type UsingIterator = Iterator<Aggregate, void, void>;
+  export type UsingIterator<T> = IterableIterator<T>;
 }
 
 export declare const Disposable: Disposable.Constructor;

--- a/disposable.js
+++ b/disposable.js
@@ -199,9 +199,10 @@ const wrapIterator = (iter, getDisposable) => {
 };
 
 /**
- * @param {DisposableAggregate} value
+ * @template T
+ * @param {T} value
  * @param {IDisposable} disposable
- * @returns {import("./disposable.js").Disposable.UsingIterator}
+ * @returns {import("./disposable.js").Disposable.UsingIterator<T>}
  */
 const getIterator = (value, disposable) => {
   /** @type {IDisposable | undefined} */
@@ -419,6 +420,17 @@ export const Disposable = /** @type {DisposableConstructor} */ (
           return wrapIterator(iterator, mapFn);
         },
       };
+    }
+
+    /**
+     * @param {any} value
+     * @param {DisposeMethod} [onDispose]
+     */
+    static using(value, onDispose) {
+      // Wrap value even if it's already a disposable
+      const disposable = new (this || Disposable)();
+      disposable.using(value, onDispose);
+      return getIterator(value, disposable);
     }
 
     static [Symbol.iterator]() {

--- a/test.js
+++ b/test.js
@@ -112,6 +112,10 @@ try {
   }
 } catch (err) {}
 
+for (const res of Disposable.using(getResource("ola"))) {
+  console.log(`using ${res.name}`);
+}
+
 for (const res of Disposable.usingFrom(getResources(testNames))) {
   console.log(`using ${res.name}`);
 }
@@ -162,6 +166,10 @@ try {
     throw new Error();
   }
 } catch (err) {}
+
+for await (const res of AsyncDisposable.using(getAsyncResource("ola"))) {
+  console.log(`using ${res.name}`);
+}
 
 for await (const res of AsyncDisposable.usingFrom(
   getAsyncResources(testNames)


### PR DESCRIPTION
Add a static `using` iterator helper that simplifies scoping the disposal of a single resource to a `for-of` statement.

Throw when calling the `using` aggregate instance helper after the instance has been disposed of. Ensures that the resource that was attempted to be added for tracking is disposed of first.